### PR TITLE
Fix strncmp_() return value

### DIFF
--- a/src/HeliOS.c
+++ b/src/HeliOS.c
@@ -150,10 +150,10 @@ int strncmp_(const char* str1_, const char* str2_, size_t n) {
 	const char* str1 = str1_;
 	while (*str1 && n--) {
 		if (*str1 != *str2) {
-			return FALSE;
+			return *str1 - *str2;
 		}
 		str1++;
 		str2++;
 	}
-	return TRUE;
+	return 0;
 }

--- a/src/task.c
+++ b/src/task.c
@@ -105,7 +105,7 @@ int xTaskGetId(const char* name_) {
 	do {
 		task = TaskListGet();
 		if (task) {
-			if (strncmp_(task->name, name_, TASKNAMESIZE)) {
+			if (strncmp_(task->name, name_, TASKNAMESIZE) == 0) {
 				return task->id;
 			}
 		}


### PR DESCRIPTION
Use standard return values from strncmp_() to improve code readability
and maintainability.