### PR TITLE
Typedef all structs

### DIFF
--- a/src/HeliOS.c
+++ b/src/HeliOS.c
@@ -36,9 +36,9 @@ void xHeliOSSetup() {
 
 void xHeliOSLoop() {
   int waiting = 0;
-  struct Task* waitingTask[WAITINGTASKSIZE];
-  struct Task* runningTask = NULL;
-  struct Task* task = NULL;
+  Task* waitingTask[WAITINGTASKSIZE];
+  Task* runningTask = NULL;
+  Task* task = NULL;
   unsigned long taskStartTime = 0;
   unsigned long leastRuntime = ULONG_MAX;
   heliOSCriticalBlocking = TRUE;
@@ -109,10 +109,10 @@ void xHeliOSLoop() {
   heliOSCriticalBlocking = FALSE;
 }
 
-struct xHeliOSGetInfoResult* xHeliOSGetInfo() {
+xHeliOSGetInfoResult* xHeliOSGetInfo() {
   int tasks = 0;
-  struct Task* task = NULL;
-  struct xHeliOSGetInfoResult* heliOSGetInfoResult = NULL;
+  Task* task = NULL;
+  xHeliOSGetInfoResult* heliOSGetInfoResult = NULL;
   TaskListRewind();
   do {
     task = TaskListGet();
@@ -120,7 +120,7 @@ struct xHeliOSGetInfoResult* xHeliOSGetInfo() {
       tasks++;
     }
   } while (TaskListMoveNext());
-  heliOSGetInfoResult = (struct xHeliOSGetInfoResult*)xMemAlloc(sizeof(struct xHeliOSGetInfoResult));
+  heliOSGetInfoResult = (xHeliOSGetInfoResult*)xMemAlloc(sizeof(xHeliOSGetInfoResult));
   if (heliOSGetInfoResult) {
     heliOSGetInfoResult->tasks = tasks;
     strncpy_(heliOSGetInfoResult->productName, PRODUCTNAME, PRODUCTNAMESIZE);

--- a/src/HeliOS.h
+++ b/src/HeliOS.h
@@ -54,50 +54,52 @@
 #define MEMALLOCTABLESIZE 50
 #define WAITINGTASKSIZE 8
 
-enum xTaskState {
+typedef enum {
   TaskStateErrored,
   TaskStateStopped,
   TaskStateRunning,
   TaskStateWaiting
-};
+} xTaskState;
 
-struct xTaskGetInfoResult {
+typedef struct {
   int id;
   char name[TASKNAMESIZE];
-  enum xTaskState state;
+  xTaskState state;
   int notifyBytes;
   char notifyValue[NOTIFYVALUESIZE];
   unsigned long lastRuntime;
   unsigned long totalRuntime;
   unsigned long timerInterval;
   unsigned long timerStartTime;
-};
+} xTaskGetInfoResult;
 
-struct xTaskGetNotifResult {
+typedef struct {
   int notifyBytes;
   char notifyValue[NOTIFYVALUESIZE];
-};
+} xTaskGetNotifResult;
 
-struct xHeliOSGetInfoResult {
+typedef struct {
   int tasks;
   char productName[PRODUCTNAMESIZE];
   int majorVersion;
   int minorVersion;
   int patchVersion;
-};
+} xHeliOSGetInfoResult;
 
-struct xTaskGetListResult {
+typedef struct {
   int id;
   char name[TASKNAMESIZE];
-  enum xTaskState state;
+  xTaskState state;
   unsigned long lastRuntime;
   unsigned long totalRuntime;
-};
+} xTaskGetListResult;
 
-struct Task {
+struct tasklistitem_s;
+
+typedef struct {
   int id;
   char name[TASKNAMESIZE];
-  enum xTaskState state;
+  xTaskState state;
   void (*callback)(int);
   int notifyBytes;
   char notifyValue[NOTIFYVALUESIZE];
@@ -105,18 +107,18 @@ struct Task {
   unsigned long totalRuntime;
   unsigned long timerInterval;
   unsigned long timerStartTime;
-  struct TaskListItem* next;
-};
+  struct tasklistitem_s* next;
+} Task;
 
-struct TaskListItem {
-  struct Task* task;
-  struct TaskListItem* next;
-};
+typedef struct tasklistitem_s {
+  Task* task;
+  struct tasklistitem_s* next;
+} TaskListItem;
 
-struct MemAllocRecord {
+typedef struct {
   size_t size;
   void* ptr;
-};
+} MemAllocRecord;
 
 #ifdef __cplusplus
 extern "C" {
@@ -124,7 +126,7 @@ extern "C" {
 
 void xHeliOSSetup();
 void xHeliOSLoop();
-struct xHeliOSGetInfoResult* xHeliOSGetInfo();
+xHeliOSGetInfoResult* xHeliOSGetInfo();
 int HeliOSIsCriticalBlocking();
 void HeliOSReset();
 void memcpy_(void*, void*, size_t);

--- a/src/list.c
+++ b/src/list.c
@@ -22,10 +22,10 @@
 #include "task.h"
 #include "timer.h"
 
-volatile struct TaskListItem* taskListHead;
-volatile struct TaskListItem* taskListTail;
-volatile struct TaskListItem* taskListPrev;
-volatile struct TaskListItem* taskListCurr;
+volatile TaskListItem* taskListHead;
+volatile TaskListItem* taskListTail;
+volatile TaskListItem* taskListPrev;
+volatile TaskListItem* taskListCurr;
 
 void TaskListInit() {
   taskListHead = NULL;
@@ -41,8 +41,8 @@ void TaskListClear() {
   }
 }
 
-void TaskListAdd(struct Task* task_) {
-  struct TaskListItem* item = (struct TaskListItem*)xMemAlloc(sizeof(struct TaskListItem));
+void TaskListAdd(Task* task_) {
+  TaskListItem* item = (TaskListItem*)xMemAlloc(sizeof(TaskListItem));
   if (item && task_) {
     item->task = task_;
     item->next = NULL;
@@ -61,25 +61,25 @@ void TaskListAdd(struct Task* task_) {
 void TaskListRemove() {
   if (taskListCurr) {
     if (taskListCurr == taskListHead && taskListCurr == taskListTail) {
-      struct TaskListItem* item = taskListHead;
+      TaskListItem* item = taskListHead;
       TaskListInit();
       xMemFree(item->task);
       xMemFree(item);
     } else if (taskListCurr == taskListHead) {
-      struct TaskListItem* item = taskListHead;
+      TaskListItem* item = taskListHead;
       taskListHead = taskListHead->next;
       TaskListRewind();
       xMemFree(item->task);
       xMemFree(item);
     } else if (taskListCurr == taskListTail) {
-      struct TaskListItem* item = taskListTail;
+      TaskListItem* item = taskListTail;
       taskListTail = taskListPrev;
       taskListPrev->next = NULL;
       TaskListRewind();
       xMemFree(item->task);
       xMemFree(item);
     } else {
-      struct TaskListItem* item = taskListCurr;
+      TaskListItem* item = taskListCurr;
       taskListPrev->next = taskListCurr->next;
       TaskListRewind();
       xMemFree(item->task);
@@ -88,7 +88,7 @@ void TaskListRemove() {
   }
 }
 
-struct Task* TaskListGet() {
+Task* TaskListGet() {
   if (taskListCurr) {
     return taskListCurr->task;
   }

--- a/src/list.h
+++ b/src/list.h
@@ -22,9 +22,9 @@ extern "C" {
 
 void TaskListInit();
 void TaskListClear();
-void TaskListAdd(struct Task*);
+void TaskListAdd(Task*);
 void TaskListRemove();
-struct Task* TaskListGet();
+Task* TaskListGet();
 int TaskListMoveNext();
 void TaskListRewind();
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -22,10 +22,10 @@
 #include "task.h"
 #include "timer.h"
 
-volatile struct MemAllocRecord memAllocTable[MEMALLOCTABLESIZE];
+volatile MemAllocRecord memAllocTable[MEMALLOCTABLESIZE];
 
 void MemInit() {
-  memset_(&memAllocTable, 0, MEMALLOCTABLESIZE * sizeof(struct MemAllocRecord));
+  memset_(&memAllocTable, 0, MEMALLOCTABLESIZE * sizeof(MemAllocRecord));
 }
 
 void* xMemAlloc(size_t size_) {

--- a/src/task.c
+++ b/src/task.c
@@ -30,7 +30,7 @@ void TaskInit() {
 
 int xTaskAdd(const char* name_, void (*callback_)(int)) {
   if(!HeliOSIsCriticalBlocking()) {
-    struct Task* task = (struct Task*)xMemAlloc(sizeof(struct Task));
+    Task* task = (Task*)xMemAlloc(sizeof(Task));
     if (task) {
       task->id = taskNextId;
       taskNextId++;
@@ -64,7 +64,7 @@ void xTaskClear() {
 }
 
 void xTaskStart(int id_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
@@ -76,7 +76,7 @@ void xTaskStart(int id_) {
 }
 
 void xTaskStop(int id_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
@@ -88,7 +88,7 @@ void xTaskStop(int id_) {
 }
 
 void xTaskWait(int id_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
@@ -100,7 +100,7 @@ void xTaskWait(int id_) {
 }
 
 int xTaskGetId(const char* name_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   TaskListRewind();
   do {
     task = TaskListGet();
@@ -114,7 +114,7 @@ int xTaskGetId(const char* name_) {
 }
 
 void xTaskNotify(int id_, int notifyBytes_, char* notifyValue_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if(notifyBytes_ > 0 && notifyBytes_ <= NOTIFYVALUESIZE && notifyValue_) {
     if (TaskListSeek(id_)) {
       task = TaskListGet();
@@ -129,7 +129,7 @@ void xTaskNotify(int id_, int notifyBytes_, char* notifyValue_) {
 }
 
 void xTaskNotifyClear(int id_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
@@ -141,13 +141,13 @@ void xTaskNotifyClear(int id_) {
   }
 }
 
-struct xTaskGetNotifResult* xTaskGetNotif(int id_) {
-  struct Task* task = NULL;
-  struct xTaskGetNotifResult* taskGetNotifResult = NULL;
+xTaskGetNotifResult* xTaskGetNotif(int id_) {
+  Task* task = NULL;
+  xTaskGetNotifResult* taskGetNotifResult = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
-      taskGetNotifResult = (struct xTaskGetNotifResult*)xMemAlloc(sizeof(struct xTaskGetNotifResult));
+      taskGetNotifResult = (xTaskGetNotifResult*)xMemAlloc(sizeof(xTaskGetNotifResult));
       if (taskGetNotifResult) {
         taskGetNotifResult->notifyBytes = task->notifyBytes;
         memcpy_(taskGetNotifResult->notifyValue, task->notifyValue, NOTIFYVALUESIZE);
@@ -157,13 +157,13 @@ struct xTaskGetNotifResult* xTaskGetNotif(int id_) {
   return taskGetNotifResult;
 }
 
-struct xTaskGetInfoResult* xTaskGetInfo(int id_) {
-  struct Task* task = NULL;
-  struct xTaskGetInfoResult* taskGetInfoResult = NULL;
+xTaskGetInfoResult* xTaskGetInfo(int id_) {
+  Task* task = NULL;
+  xTaskGetInfoResult* taskGetInfoResult = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
-      taskGetInfoResult = (struct xTaskGetInfoResult*)xMemAlloc(sizeof(struct xTaskGetInfoResult));
+      taskGetInfoResult = (xTaskGetInfoResult*)xMemAlloc(sizeof(xTaskGetInfoResult));
       if (taskGetInfoResult) {
         taskGetInfoResult->id = task->id;
         memcpy_(taskGetInfoResult->name, task->name, TASKNAMESIZE);
@@ -181,7 +181,7 @@ struct xTaskGetInfoResult* xTaskGetInfo(int id_) {
 }
 
 int TaskListSeek(int id_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   TaskListRewind();
   do {
     task = TaskListGet();
@@ -194,11 +194,11 @@ int TaskListSeek(int id_) {
   return FALSE;
 }
 
-struct xTaskGetListResult* xTaskGetList(int* tasks_) {
+xTaskGetListResult* xTaskGetList(int* tasks_) {
   int i = 0;
   int tasks = 0;
-  struct Task* task = NULL;
-  struct xTaskGetListResult* taskGetListResult = NULL;
+  Task* task = NULL;
+  xTaskGetListResult* taskGetListResult = NULL;
   *tasks_ = 0;
   TaskListRewind();
   do {
@@ -208,7 +208,7 @@ struct xTaskGetListResult* xTaskGetList(int* tasks_) {
     }
   } while (TaskListMoveNext());
   if (tasks > 0) {
-    taskGetListResult = (struct xTaskGetListResult*)xMemAlloc(tasks * sizeof(struct xTaskGetListResult));
+    taskGetListResult = (xTaskGetListResult*)xMemAlloc(tasks * sizeof(xTaskGetListResult));
     if (taskGetListResult) {
       TaskListRewind();
       do {
@@ -229,7 +229,7 @@ struct xTaskGetListResult* xTaskGetList(int* tasks_) {
 }
 
 void xTaskSetTimer(int id_, unsigned long timerInterval_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {
@@ -242,7 +242,7 @@ void xTaskSetTimer(int id_, unsigned long timerInterval_) {
 }
 
 void xTaskResetTimer(int id_) {
-  struct Task* task = NULL;
+  Task* task = NULL;
   if (TaskListSeek(id_)) {
     task = TaskListGet();
     if (task) {

--- a/src/task.h
+++ b/src/task.h
@@ -30,10 +30,10 @@ void xTaskWait(int);
 int xTaskGetId(const char*);
 void xTaskNotify(int, int, char*);
 void xTaskNotifyClear(int);
-struct xTaskGetNotifResult* xTaskGetNotif(int);
-struct xTaskGetInfoResult* xTaskGetInfo(int);
+xTaskGetNotifResult* xTaskGetNotif(int);
+xTaskGetInfoResult* xTaskGetInfo(int);
 int TaskListSeek(int);
-struct xTaskGetListResult* xTaskGetList(int*);
+xTaskGetListResult* xTaskGetList(int*);
 void xTaskSetTimer(int, unsigned long);
 void xTaskResetTimer(int);
 


### PR DESCRIPTION
Every (or most) struct definition is replaced with typedef. This change allow to replace things like "struct Task *" with simpler "Task *"