### PR TITLE
add support for ESP8266, minor changes to supress compilation warnings

### DIFF
--- a/src/HeliOS.c
+++ b/src/HeliOS.c
@@ -77,9 +77,9 @@ void xHeliOSLoop() {
       TaskRun(waitingTask[i]);
       waitingTask[i]->notifyBytes = 0;
     } else if (waitingTask[i]->timerInterval > 0) {
-      if (NOW() - waitingTask[i]->timerStartTime > waitingTask[i]->timerInterval) {
+      if (SYS_NOW() - waitingTask[i]->timerStartTime > waitingTask[i]->timerInterval) {
         TaskRun(waitingTask[i]);
-        waitingTask[i]->timerStartTime = NOW();
+        waitingTask[i]->timerStartTime = SYS_NOW();
       }
     }
   }
@@ -137,7 +137,7 @@ inline Time_t CurrentTime() {
     return t.tv_sec * 1000000 + t.tv_nsec / 1000;
 #else
     /*
-     * Since CurrentTime() is not defined for NOW() on
+     * Since CurrentTime() is not defined for SYS_NOW() on
      * the Arduino architectures, just return zero.
      */
     return 0;
@@ -149,9 +149,9 @@ inline void TaskRun(Task_t *task_) {
   Time_t prevTotalRuntime = 0;
 
   prevTotalRuntime = task_->totalRuntime;
-  taskStartTime = NOW();
+  taskStartTime = SYS_NOW();
   (*task_->callback)(task_->id);
-  task_->lastRuntime = NOW() - taskStartTime;
+  task_->lastRuntime = SYS_NOW() - taskStartTime;
   task_->totalRuntime += task_->lastRuntime;
   if (task_->totalRuntime < prevTotalRuntime)
     flags.runtimeOverflow = true;

--- a/src/HeliOS.h
+++ b/src/HeliOS.h
@@ -30,35 +30,42 @@
 
 #if defined(ARDUINO_ARCH_AVR)
   #include <Arduino.h>
-  #define NOW() micros()
+  #define SYS_NOW() micros()
   #define DISABLE() noInterrupts()
   #define ENABLE() interrupts()
   typedef uint32_t Time_t;
   #define TIME_T_MAX UINT32_MAX
 #elif defined(ARDUINO_ARCH_SAM)
   #include <Arduino.h>
-  #define NOW() micros()
+  #define SYS_NOW() micros()
   #define DISABLE() noInterrupts()
   #define ENABLE() interrupts()
   typedef uint32_t Time_t;
   #define TIME_T_MAX UINT32_MAX
 #elif defined(ARDUINO_ARCH_SAMD)
   #include <Arduino.h>
-  #define NOW() micros()
+  #define SYS_NOW() micros()
+  #define DISABLE() noInterrupts()
+  #define ENABLE() interrupts()
+  typedef uint32_t Time_t;
+  #define TIME_T_MAX UINT32_MAX
+#elif defined(ARDUINO_ARCH_ESP8266)
+  #include <Arduino.h>
+  #define SYS_NOW() micros()
   #define DISABLE() noInterrupts()
   #define ENABLE() interrupts()
   typedef uint32_t Time_t;
   #define TIME_T_MAX UINT32_MAX
 #elif defined(OTHER_ARCH_LINUX)
   #include <time.h>
-  #define NOW() CurrentTime()
+  #define SYS_NOW() CurrentTime()
   #define DISABLE()
   #define ENABLE()
   typedef uint64_t Time_t;
   #define TIME_T_MAX UINT64_MAX
 #elif defined(OTHER_ARCH_WINDOWS)
   #include <Windows.h>
-  #define NOW() CurrentTime()
+  #define SYS_NOW() CurrentTime()
   #define DISABLE()
   #define ENABLE()
   typedef int64_t Time_t;

--- a/src/list.c
+++ b/src/list.c
@@ -60,25 +60,25 @@ void TaskListAdd(Task_t *task_) {
 void TaskListRemove() {
   if (taskListCurr) {
     if (taskListCurr == taskListHead && taskListCurr == taskListTail) {
-      TaskListItem_t *item = taskListHead;
+      TaskListItem_t *item = (TaskListItem_t*)taskListHead;
       TaskListInit();
       xMemFree(item->task);
       xMemFree(item);
     } else if (taskListCurr == taskListHead) {
-      TaskListItem_t *item = taskListHead;
+      TaskListItem_t *item = (TaskListItem_t*)taskListHead;
       taskListHead = taskListHead->next;
       TaskListRewind();
       xMemFree(item->task);
       xMemFree(item);
     } else if (taskListCurr == taskListTail) {
-      TaskListItem_t *item = taskListTail;
+      TaskListItem_t *item = (TaskListItem_t*)taskListTail;
       taskListTail = taskListPrev;
       taskListPrev->next = null;
       TaskListRewind();
       xMemFree(item->task);
       xMemFree(item);
     } else {
-      TaskListItem_t *item = taskListCurr;
+      TaskListItem_t *item = (TaskListItem_t*)taskListCurr;
       taskListPrev->next = taskListCurr->next;
       TaskListRewind();
       xMemFree(item->task);

--- a/src/task.c
+++ b/src/task.c
@@ -231,7 +231,7 @@ void xTaskSetTimer(TaskId_t id_, Time_t timerInterval_) {
     if (task) {
       if (task->state != TaskStateInvalid) {
         task->timerInterval = timerInterval_;
-        task->timerStartTime = NOW();
+        task->timerStartTime = SYS_NOW();
       }
     }
   }
@@ -244,6 +244,6 @@ void xTaskResetTimer(TaskId_t id_) {
     task = TaskListGet();
     if (task)
       if (task->state != TaskStateInvalid)
-        task->timerStartTime = NOW();
+        task->timerStartTime = SYS_NOW();
   }
 }


### PR DESCRIPTION
Changes I've made:
1) Support for ESP8266 - just add new section to HeliOS.h with `ARDUINO_ARCH_ESP8266`, identical to others `ARDUINO_ARCH_xxx`.
2) Renamed macro `NOW()` to something less generic: `SYS_NOW()` - without this compiler warns about macro redefinition - NOW() macro is defined in some ESP-specific Arduino libraries.
3) Changed `TaskListItem_t *item = taskListHead` to `TaskListItem_t *item = (TaskListItem_t*)taskListHead` in function `TaskListRemove()` - without this compiler warns about discarding volatile qualifier (`taskListHead` is defined as volatile).

Tested on NodeMCU board with ESP8266. Everything works like a charm and compiles without any warnings.